### PR TITLE
PLATUI-561: New page-accessibility-check.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ app/pages
 app/accessibility-assessment-service.log
 app/global-filters.conf
 output/
+/pages/
+/test/elk/esdata/

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -26,3 +26,4 @@ docker run --cpus 3  \
 # -v ${PROJECT_DIR}/app/routes:/home/seluser/app/routes \
 # -v ${PROJECT_DIR}/app/app.js:/home/seluser/app/app.js \
 # -v ${PROJECT_DIR}/app/services/globals.js:/home/seluser/app/services/globals.js \
+# -v ${PROJECT_DIR}/pages:/home/seluser/pages \


### PR DESCRIPTION
The jar has changes to suppress logging to console which prevents
`stdout maxBuffer length exceeded` error.
Added /pages and /test/elk/esdata folders to gitignore. These are required only for local usage.