### PR TITLE
PLATUI-642: Updated `express-fileupload` version 

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -822,9 +822,9 @@
       }
     },
     "express-fileupload": {
-      "version": "1.1.7-alpha.3",
-      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.1.7-alpha.3.tgz",
-      "integrity": "sha512-2YRJQqjgfFcYiMr8inico+UQ0UsxuOUyO9wkWkx+vjsEcUI7c1ae38Nv5NKdGjHqL5+J01P6StT9mjZTI7Qzjg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.1.9.tgz",
+      "integrity": "sha512-f2w0aoe7lj3NeD8a4MXmYQsqir3Z66I08l9AKq04QbFUAjeZNmPwTlR5Lx2NGwSu/PslsAjGC38MWzo5tTjoBg==",
       "requires": {
         "busboy": "^0.3.1"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,7 @@
     "archiver": "^3.1.1",
     "errorhandler": "^1.4.3",
     "express": "^4.17.1",
-    "express-fileupload": "^1.1.7-alpha.3",
+    "express-fileupload": "^1.1.9",
     "rimraf": "^3.0.2",
     "node-sass": "^4.13.1",
     "pug": "^2.0.4"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome:3.141.59-20200525
+FROM selenium/node-chrome:3.141.59-20200730
 
 ENV CAPTURE_ALL_PAGES false
 ENV APP_PORT 6010


### PR DESCRIPTION
This version address security vulnerability CVE-2020-7699.

Building a new image resulted in axe-cli using the latest version of chromedriver(84) which required updating Selenium version in Dockerfile to use Chrome 84.