### PR TITLE
Plat UI 1547 inline page accessibility check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 PYTHON_VERSION := $(shell cat .python-version)
 
-.PHONY: check_docker copy_files clean_local build_local run_local stop_local build authenticate_to_artifactory push_image prep_version_incrementor clean help compose
+.PHONY: check_docker copy_files clean_local build_local run_local stop_local build authenticate_to_artifactory push_image prep_version_incrementor clean help compose build_page_accessibility_check
 .DEFAULT_GOAL := help
 
 copy_files: ## Copies files required for building image
@@ -15,7 +15,7 @@ clean_local: stop_local ## Clean up local environment
 	@docker rmi -f accessibility-assessment:SNAPSHOT
 	@rm -rf docker/files/accessibility-assessment-service
 
-build_local: clean_local copy_files ## Builds the accessibility-assessment image locally
+build_local: clean_local build_page_accessibility_check copy_files ## Builds the accessibility-assessment image locally
 	@echo '********** Building docker image for local use ************'
 	@docker build --progress=plain --no-cache --tag accessibility-assessment:SNAPSHOT docker \
  	|| (echo "Build failed. Removing files used for building"; rm -rf docker/files/accessibility-assessment-service; exit 1)
@@ -30,7 +30,11 @@ stop_local: ## Stops the a11y container
 	@echo '********** Stopping a11y container running locally ************'
 	@docker stop a11y || (echo "a11y container not running. Nothing to stop."; exit 0)
 
-build: copy_files prep_version_incrementor ## Build the docker image
+build_page_accessibility_check:
+	@cd page-accessibility-check && \
+		sbt 'set test in assembly := {}' clean assembly
+
+build: build_page_accessibility_check copy_files prep_version_incrementor ## Build the docker image
 	@echo '********** Building docker image ************'
 	@pipenv run prepare-release
 	@umask 0022

--- a/page-accessibility-check/build.sbt
+++ b/page-accessibility-check/build.sbt
@@ -1,6 +1,6 @@
 mainClass in (Compile, packageBin) := Some("uk.gov.hmrc.a11y.PageAccessibilityCheck")
 
-assemblyJarName in assembly := "page-accessibility-check.jar"
+assemblyOutputPath in assembly := baseDirectory.value / ".." / "accessibility-assessment-service" / "app" / "resources" / "page-accessibility-check.jar"
 
 lazy val testSuite = (project in file("."))
   .enablePlugins(SbtAutoBuildPlugin)

--- a/page-accessibility-check/src/test/scala/uk/gov/hmrc/a11y/config/ConfigurationSpec.scala
+++ b/page-accessibility-check/src/test/scala/uk/gov/hmrc/a11y/config/ConfigurationSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ */
+
 package uk.gov.hmrc.a11y.config
 
 import com.typesafe.config.{Config, ConfigException, ConfigFactory}


### PR DESCRIPTION
draft PR that inlines the hmrc/page-accessibility-check sbt project into this repository so we can build the fatjar that's not used by anything else alongside this docker image. I've created another branch which just copies the files unchanged to a subfolder and used that as the base for this so as not to have a large diff (it was crashing my browser trying to load the PR otherwise!)