### PR TITLE
PLATUI-1623: npm audit fix in root project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2943,9 +2943,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "forever-agent": {
       "version": "0.6.1",


### PR DESCRIPTION
created my own PR rather than dependabot because I there was another minor version to go up and I wanted to run tests

I've also proposed removing the audit job for the tools https://github.com/hmrc/build-jobs/pull/10351/files which seems to no longer be needed