### PR TITLE
PLATUI-1871 - Bumping axe-core and version of chrome browser to latest

### DIFF
--- a/accessibility-assessment-service/test/e2e/e2e.test.js
+++ b/accessibility-assessment-service/test/e2e/e2e.test.js
@@ -104,7 +104,7 @@ describe('accessibility-assessment-service', () => {
                 expect(JSON.stringify(axe)).toContain('Document has more than one main landmark')
                 //violation from VNU
                 expect(JSON.stringify(vnu)).toContain('A document must not include more than one visible “main” element.')
-                expect(axe['version']).toEqual('4.3.5')
+                expect(axe['version']).toEqual('4.4.3')
                 expect(vnu['version']).toEqual('21.10.12')
                 //page URL
                 expect(axe['paths'][0]['pages'][0]['url']).toContain('https://build.tax.service.gov.uk/job/ACE/job/awesome-tests-a11y-tests/19/')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKERHUB=dockerhub.tax.service.gov.uk
-FROM ${DOCKERHUB}/selenium/node-chrome:3.141.59-20201119
+FROM ${DOCKERHUB}/selenium/node-chrome:103.0-20220706
 
 ENV CAPTURE_ALL_PAGES false
 ENV APP_PORT 6010
@@ -43,6 +43,10 @@ RUN   cd ${HOME} \
       # The name of the shell script should match the invocation from page-accessibility-check.
       && sudo echo -e '#!/bin/bash\njava -jar ${HOME}/accessibility-assessment-service/node_modules/vnu-jar/build/dist/vnu.jar "$@"' > ${HOME}/bin/vnu \
       && sudo echo -e '#!/bin/bash\n cd ${HOME}/accessibility-assessment-service;npx axe "$@"' > ${HOME}/bin/axeRunner \
+      # A breaking change was introduced in selenium-webdriver 4.3.1. removing chrome.setDefaultService
+      # The below used selenium-webdriver 4.3.0 is used to resolve this issue so axe can run.
+      # Further info: https://github.com/dequelabs/axe-core-npm/issues/538#issuecomment-1177804416
+      && npm install selenium-webdriver@4.3.0 --save-exact \
       # makes axe and vnu shell scripts executable
       && chmod +x ${HOME}/bin/vnu \
       && chmod +x ${HOME}/bin/axeRunner \

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "pug": "^3.0.1",
     "jest": "^27.3.0",
     "supertest": "^6.1.3",
-    "@axe-core/cli": "4.3.2",
-    "axe-core": "4.3.5",
+    "@axe-core/cli": "4.4.3",
+    "axe-core": "4.4.3",
     "vnu-jar": "21.10.12"
   },
   "devDependencies": {


### PR DESCRIPTION
* Updating Jest e2e test to check for newer version of axe
*  Introducing temporary fix to use version 4.3.0 of selenium-webdriver as the latest is a breaking change that stop axe from running